### PR TITLE
Fixed - `additionalFields` improperly defined

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -9,7 +9,7 @@
  * @returns
  */
 export function createSelectedFields(queryInfo: any, options?: {
-    additionalFields?: [string];
+    additionalFields?: string[];
     path?: string;
     returnType?: string;
 }): any;


### PR DESCRIPTION
additionalFields is defined as a array with one string value. Updated type to be an array of multiple strings.